### PR TITLE
Add language selector and breadcrumbs

### DIFF
--- a/project-bolt-sb1-ukem6591/project/app/collections/page.tsx
+++ b/project-bolt-sb1-ukem6591/project/app/collections/page.tsx
@@ -7,6 +7,8 @@ import { SAMPLE_PRODUCTS, PRODUCT_COLLECTIONS, PRODUCT_CATEGORIES, GENDER_FILTER
 import { ProductCard } from '@/components/ui/product-card';
 import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Breadcrumbs } from '@/components/layout/breadcrumbs';
+import { useLanguage } from '@/lib/language-context';
 
 export default function CollectionsPage() {
   const searchParams = useSearchParams();
@@ -15,6 +17,7 @@ export default function CollectionsPage() {
   const [selectedGender, setSelectedGender] = useState(searchParams.get('gender') || 'all');
   const [selectedType, setSelectedType] = useState(searchParams.get('type') || 'all');
   const [sortBy, setSortBy] = useState('name');
+  const { t } = useLanguage();
 
   const filteredProducts = useMemo(() => {
     let products = [...SAMPLE_PRODUCTS];
@@ -112,6 +115,15 @@ export default function CollectionsPage() {
           </motion.div>
         </div>
       </section>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+        <Breadcrumbs
+          items={[
+            { label: t.home, href: '/' },
+            { label: t.collections },
+          ]}
+        />
+      </div>
 
       {/* Collection Filter */}
       <section className="py-6 bg-gray-50 border-b">

--- a/project-bolt-sb1-ukem6591/project/app/layout.tsx
+++ b/project-bolt-sb1-ukem6591/project/app/layout.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import { Header } from '@/components/layout/header';
 import { Footer } from '@/components/layout/footer';
-import { CartProvider } from '@/lib/cart-context';
+import { Providers } from '@/components/providers';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -20,13 +20,13 @@ export default function RootLayout({
   return (
     <html lang="fr">
       <body className={inter.className}>
-        <CartProvider>
+        <Providers>
           <Header />
           <main>
             {children}
           </main>
           <Footer />
-        </CartProvider>
+        </Providers>
       </body>
     </html>
   );

--- a/project-bolt-sb1-ukem6591/project/app/products/[id]/page.tsx
+++ b/project-bolt-sb1-ukem6591/project/app/products/[id]/page.tsx
@@ -11,6 +11,8 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Breadcrumbs } from '@/components/layout/breadcrumbs';
+import { useLanguage } from '@/lib/language-context';
 
 interface ProductPageProps {
   params: {
@@ -23,6 +25,7 @@ export default function ProductPage({ params }: ProductPageProps) {
   const [selectedSize, setSelectedSize] = useState('');
   const [selectedImage, setSelectedImage] = useState(0);
   const { dispatch } = useCart();
+  const { t } = useLanguage();
 
   if (!product) {
     notFound();
@@ -45,6 +48,15 @@ export default function ProductPage({ params }: ProductPageProps) {
 
   return (
     <div className="pt-16">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+        <Breadcrumbs
+          items={[
+            { label: t.home, href: '/' },
+            { label: t.collections, href: '/collections' },
+            { label: product.name },
+          ]}
+        />
+      </div>
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-16">
           {/* Product Images */}

--- a/project-bolt-sb1-ukem6591/project/components/layout/breadcrumbs.tsx
+++ b/project-bolt-sb1-ukem6591/project/components/layout/breadcrumbs.tsx
@@ -1,0 +1,39 @@
+'use client';
+import React from 'react';
+import Link from 'next/link';
+import {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbSeparator,
+  BreadcrumbPage,
+} from '@/components/ui/breadcrumb';
+
+interface Crumb {
+  label: string;
+  href?: string;
+}
+
+export function Breadcrumbs({ items }: { items: Crumb[] }) {
+  return (
+    <Breadcrumb>
+      <BreadcrumbList>
+        {items.map((item, index) => (
+          <React.Fragment key={index}>
+            <BreadcrumbItem>
+              {item.href ? (
+                <BreadcrumbLink asChild>
+                  <Link href={item.href}>{item.label}</Link>
+                </BreadcrumbLink>
+              ) : (
+                <BreadcrumbPage>{item.label}</BreadcrumbPage>
+              )}
+            </BreadcrumbItem>
+            {index < items.length - 1 && <BreadcrumbSeparator />}
+          </React.Fragment>
+        ))}
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+}

--- a/project-bolt-sb1-ukem6591/project/components/layout/header.tsx
+++ b/project-bolt-sb1-ukem6591/project/components/layout/header.tsx
@@ -6,16 +6,19 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { Menu, X, ShoppingBag, User } from 'lucide-react';
 import { useCart } from '@/lib/cart-context';
 import { Button } from '@/components/ui/button';
-
-const navigation = [
-  { name: 'Collections', href: '/collections' },
-  { name: 'À propos', href: '/about' },
-  { name: 'Contact', href: '/contact' },
-];
+import { useLanguage } from '@/lib/language-context';
 
 export function Header() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const { state } = useCart();
+  const { t, lang, setLang } = useLanguage();
+
+  const navigation = [
+    { name: t.home, href: '/' },
+    { name: t.collections, href: '/collections' },
+    { name: t.about, href: '/about' },
+    { name: t.contact, href: '/contact' },
+  ];
 
   return (
     <header className="fixed top-0 w-full z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
@@ -37,6 +40,14 @@ export function Header() {
                 {item.name}
               </Link>
             ))}
+            <select
+              value={lang}
+              onChange={(e) => setLang(e.target.value as 'fr' | 'en')}
+              className="text-sm border border-gray-300 rounded-md bg-white px-2 py-1"
+            >
+              <option value="fr">FR</option>
+              <option value="en">EN</option>
+            </select>
           </nav>
 
           {/* Right side icons */}
@@ -92,8 +103,16 @@ export function Header() {
                 className="block text-gray-700 hover:text-black transition-colors duration-200"
                 onClick={() => setIsMenuOpen(false)}
               >
-                Mon compte
+                {t.account}
               </Link>
+              <select
+                value={lang}
+                onChange={(e) => setLang(e.target.value as 'fr' | 'en')}
+                className="mt-2 w-full border border-gray-300 rounded-md px-2 py-1"
+              >
+                <option value="fr">FR</option>
+                <option value="en">EN</option>
+              </select>
             </div>
           </motion.div>
         )}

--- a/project-bolt-sb1-ukem6591/project/components/providers.tsx
+++ b/project-bolt-sb1-ukem6591/project/components/providers.tsx
@@ -1,0 +1,12 @@
+'use client';
+import { ReactNode } from 'react';
+import { CartProvider } from '@/lib/cart-context';
+import { LanguageProvider } from '@/lib/language-context';
+
+export function Providers({ children }: { children: ReactNode }) {
+  return (
+    <LanguageProvider>
+      <CartProvider>{children}</CartProvider>
+    </LanguageProvider>
+  );
+}

--- a/project-bolt-sb1-ukem6591/project/lib/language-context.tsx
+++ b/project-bolt-sb1-ukem6591/project/lib/language-context.tsx
@@ -1,0 +1,51 @@
+'use client';
+import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+
+type Language = 'fr' | 'en';
+
+const translations = {
+  fr: {
+    home: 'Accueil',
+    collections: 'Collections',
+    about: 'À propos',
+    contact: 'Contact',
+    account: 'Mon compte'
+  },
+  en: {
+    home: 'Home',
+    collections: 'Collections',
+    about: 'About',
+    contact: 'Contact',
+    account: 'Account'
+  }
+};
+
+interface LanguageContextValue {
+  lang: Language;
+  t: typeof translations.fr;
+  setLang: (lang: Language) => void;
+}
+
+const LanguageContext = createContext<LanguageContextValue | undefined>(undefined);
+
+export function LanguageProvider({ children }: { children: ReactNode }) {
+  const [lang, setLang] = useState<Language>('fr');
+  useEffect(() => {
+    const stored = localStorage.getItem('lang') as Language | null;
+    if (stored) setLang(stored);
+  }, []);
+  useEffect(() => {
+    localStorage.setItem('lang', lang);
+  }, [lang]);
+  return (
+    <LanguageContext.Provider value={{ lang, setLang, t: translations[lang] }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+}
+
+export function useLanguage() {
+  const ctx = useContext(LanguageContext);
+  if (!ctx) throw new Error('useLanguage must be used within a LanguageProvider');
+  return ctx;
+}


### PR DESCRIPTION
## Summary
- create a language context and provider
- wrap the app in Providers
- add language dropdown to header
- implement breadcrumb component
- show breadcrumbs on collection and product pages

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fb7b627bc83278429fa3d2d36c27d