### PR TITLE
Add signup workflow

### DIFF
--- a/project-bolt-sb1-ukem6591/project/app/globals.css
+++ b/project-bolt-sb1-ukem6591/project/app/globals.css
@@ -78,5 +78,6 @@
   }
   body {
     @apply bg-background text-foreground;
+    scrollbar-gutter: stable;
   }
 }

--- a/project-bolt-sb1-ukem6591/project/app/products/[id]/ProductPageClient.tsx
+++ b/project-bolt-sb1-ukem6591/project/app/products/[id]/ProductPageClient.tsx
@@ -7,6 +7,7 @@ import { motion } from 'framer-motion';
 import { Heart, ShoppingBag, Check, Star } from 'lucide-react';
 import { SAMPLE_PRODUCTS } from '@/lib/constants';
 import { useCart } from '@/lib/cart-context';
+import { useFavorites } from '@/lib/favorites-context';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
@@ -25,7 +26,27 @@ export default function ProductPage({ params }: ProductPageProps) {
   const [selectedSize, setSelectedSize] = useState('');
   const [selectedImage, setSelectedImage] = useState(0);
   const { dispatch } = useCart();
+  const { state: favoritesState, dispatch: favoritesDispatch } = useFavorites();
   const { t } = useLanguage();
+
+  const isFavorite = favoritesState.items.some(item => item.id === product?.id);
+
+  const toggleFavorite = () => {
+    if (!product) return;
+    if (isFavorite) {
+      favoritesDispatch({ type: 'REMOVE', payload: product.id });
+    } else {
+      favoritesDispatch({
+        type: 'ADD',
+        payload: {
+          id: product.id,
+          name: product.name,
+          price: product.price,
+          image: product.images[0],
+        },
+      });
+    }
+  };
 
   if (!product) {
     notFound();
@@ -175,8 +196,15 @@ export default function ProductPage({ params }: ProductPageProps) {
                   {!product.inStock ? 'Rupture de stock' : 'Ajouter au panier'}
                 </Button>
                 
-                <Button variant="outline" size="lg" className="px-6">
-                  <Heart className="w-5 h-5" />
+                <Button
+                  variant="outline"
+                  size="lg"
+                  className="px-6"
+                  onClick={toggleFavorite}
+                >
+                  <Heart
+                    className={`w-5 h-5 ${isFavorite ? 'fill-red-500 text-red-500' : ''}`}
+                  />
                 </Button>
               </div>
 

--- a/project-bolt-sb1-ukem6591/project/app/signup/page.tsx
+++ b/project-bolt-sb1-ukem6591/project/app/signup/page.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { useUser } from '@/lib/user-context';
+
+export default function SignupPage() {
+  const { setUser } = useUser();
+  const router = useRouter();
+
+  const [form, setForm] = useState({
+    firstName: '',
+    lastName: '',
+    email: '',
+    password: '',
+  });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm({ ...form, [e.target.id]: e.target.value });
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setUser({ ...form });
+    router.push('/account');
+  };
+
+  return (
+    <div className="pt-16 flex justify-center py-12 px-4">
+      <div className="w-full max-w-md space-y-6">
+        <h1 className="text-3xl font-bold text-center">Créer un compte</h1>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <Label htmlFor="firstName">Prénom</Label>
+            <Input id="firstName" value={form.firstName} onChange={handleChange} required />
+          </div>
+          <div>
+            <Label htmlFor="lastName">Nom</Label>
+            <Input id="lastName" value={form.lastName} onChange={handleChange} required />
+          </div>
+          <div>
+            <Label htmlFor="email">Email</Label>
+            <Input id="email" type="email" value={form.email} onChange={handleChange} required />
+          </div>
+          <div>
+            <Label htmlFor="password">Mot de passe</Label>
+            <Input id="password" type="password" value={form.password} onChange={handleChange} required />
+          </div>
+          <Button type="submit" className="w-full bg-black text-white hover:bg-gray-800">
+            Créer mon compte
+          </Button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/project-bolt-sb1-ukem6591/project/components/layout/header.tsx
+++ b/project-bolt-sb1-ukem6591/project/components/layout/header.tsx
@@ -7,11 +7,13 @@ import { Menu, X, ShoppingBag, User } from 'lucide-react';
 import { useCart } from '@/lib/cart-context';
 import { Button } from '@/components/ui/button';
 import { useLanguage } from '@/lib/language-context';
+import { useUser } from '@/lib/user-context';
 
 export function Header() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const { state } = useCart();
   const { t, lang, setLang } = useLanguage();
+  const { user } = useUser();
 
   const navigation = [
     { name: t.home, href: '/' },
@@ -52,9 +54,11 @@ export function Header() {
 
           {/* Right side icons */}
           <div className="flex items-center space-x-4">
-            <Button variant="ghost" size="sm" className="hidden md:flex">
-              <User className="w-5 h-5" />
-            </Button>
+            <Link href={user ? '/account' : '/signup'}>
+              <Button variant="ghost" size="sm" className="hidden md:flex">
+                <User className="w-5 h-5" />
+              </Button>
+            </Link>
             
             <Link href="/cart" className="relative">
               <Button variant="ghost" size="sm">
@@ -101,7 +105,7 @@ export function Header() {
                 </Link>
               ))}
               <Link
-                href="/account"
+                href={user ? '/account' : '/signup'}
                 className="block text-gray-700 hover:text-black transition-colors duration-200"
                 onClick={() => setIsMenuOpen(false)}
               >

--- a/project-bolt-sb1-ukem6591/project/components/providers.tsx
+++ b/project-bolt-sb1-ukem6591/project/components/providers.tsx
@@ -2,11 +2,17 @@
 import { ReactNode } from 'react';
 import { CartProvider } from '@/lib/cart-context';
 import { LanguageProvider } from '@/lib/language-context';
+import { FavoritesProvider } from '@/lib/favorites-context';
+import { UserProvider } from '@/lib/user-context';
 
 export function Providers({ children }: { children: ReactNode }) {
   return (
     <LanguageProvider>
-      <CartProvider>{children}</CartProvider>
+      <UserProvider>
+        <CartProvider>
+          <FavoritesProvider>{children}</FavoritesProvider>
+        </CartProvider>
+      </UserProvider>
     </LanguageProvider>
   );
 }

--- a/project-bolt-sb1-ukem6591/project/lib/favorites-context.tsx
+++ b/project-bolt-sb1-ukem6591/project/lib/favorites-context.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import React, { createContext, useContext, useReducer, ReactNode } from 'react';
+
+interface FavoriteItem {
+  id: string;
+  name: string;
+  price: number;
+  image: string;
+}
+
+interface FavoritesState {
+  items: FavoriteItem[];
+}
+
+type FavoritesAction =
+  | { type: 'ADD'; payload: FavoriteItem }
+  | { type: 'REMOVE'; payload: string };
+
+const initialState: FavoritesState = { items: [] };
+
+function favoritesReducer(state: FavoritesState, action: FavoritesAction): FavoritesState {
+  switch (action.type) {
+    case 'ADD':
+      if (state.items.find(item => item.id === action.payload.id)) {
+        return state;
+      }
+      return { items: [...state.items, action.payload] };
+    case 'REMOVE':
+      return { items: state.items.filter(item => item.id !== action.payload) };
+    default:
+      return state;
+  }
+}
+
+const FavoritesContext = createContext<{
+  state: FavoritesState;
+  dispatch: React.Dispatch<FavoritesAction>;
+} | null>(null);
+
+export function FavoritesProvider({ children }: { children: ReactNode }) {
+  const [state, dispatch] = useReducer(favoritesReducer, initialState);
+  return (
+    <FavoritesContext.Provider value={{ state, dispatch }}>
+      {children}
+    </FavoritesContext.Provider>
+  );
+}
+
+export function useFavorites() {
+  const context = useContext(FavoritesContext);
+  if (!context) {
+    throw new Error('useFavorites must be used within a FavoritesProvider');
+  }
+  return context;
+}

--- a/project-bolt-sb1-ukem6591/project/lib/user-context.tsx
+++ b/project-bolt-sb1-ukem6591/project/lib/user-context.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+
+export interface User {
+  firstName: string;
+  lastName: string;
+  email: string;
+  password: string;
+  phone?: string;
+}
+
+interface UserContextValue {
+  user: User | null;
+  setUser: (user: User | null) => void;
+}
+
+const UserContext = createContext<UserContextValue | undefined>(undefined);
+
+export function UserProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(null);
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem('user');
+      if (stored) setUser(JSON.parse(stored));
+    } catch (e) {
+      console.error('Failed to load user from storage', e);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (user) {
+      localStorage.setItem('user', JSON.stringify(user));
+    } else {
+      localStorage.removeItem('user');
+    }
+  }, [user]);
+
+  return (
+    <UserContext.Provider value={{ user, setUser }}>
+      {children}
+    </UserContext.Provider>
+  );
+}
+
+export function useUser() {
+  const context = useContext(UserContext);
+  if (!context) {
+    throw new Error('useUser must be used within a UserProvider');
+  }
+  return context;
+}


### PR DESCRIPTION
## Summary
- implement `UserProvider` for persisting account data
- create `signup` page for account creation
- connect account page and header to user context

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684fe6e2ca288327986296c07b599c61