### PR TITLE
Add variant selectors

### DIFF
--- a/miral-cycling-project/project/app/globals.css
+++ b/miral-cycling-project/project/app/globals.css
@@ -80,4 +80,8 @@
     @apply bg-background text-foreground;
     scrollbar-gutter: stable both-edges;
   }
+
+  body[data-scroll-locked] {
+    padding-right: var(--removed-body-scroll-bar-size);
+  }
 }

--- a/miral-cycling-project/project/app/products/[id]/ProductPageClient.tsx
+++ b/miral-cycling-project/project/app/products/[id]/ProductPageClient.tsx
@@ -25,6 +25,8 @@ export default function ProductPage({ params }: ProductPageProps) {
   const product = SAMPLE_PRODUCTS.find(p => p.id === params.id);
   const [selectedSize, setSelectedSize] = useState('');
   const [selectedImage, setSelectedImage] = useState(0);
+  const [selectedGender, setSelectedGender] = useState(product?.genders?.[0] || 'Male');
+  const [selectedColor, setSelectedColor] = useState(product?.colors?.[0] || null);
   const { dispatch } = useCart();
   const { state: favoritesState, dispatch: favoritesDispatch } = useFavorites();
   const { t } = useLanguage();
@@ -54,7 +56,7 @@ export default function ProductPage({ params }: ProductPageProps) {
 
   const handleAddToCart = () => {
     if (!selectedSize) return;
-    
+
     dispatch({
       type: 'ADD_ITEM',
       payload: {
@@ -62,6 +64,8 @@ export default function ProductPage({ params }: ProductPageProps) {
         name: product.name,
         price: product.price,
         size: selectedSize,
+        gender: selectedGender,
+        color: selectedColor?.name,
         image: product.images[0]
       }
     });
@@ -164,6 +168,39 @@ export default function ProductPage({ params }: ProductPageProps) {
               <p className="text-gray-600 leading-relaxed mb-8">
                 {product.description}
               </p>
+
+              {product.genders && (
+                <div className="mb-6 space-y-2">
+                  <label className="block text-sm font-medium text-gray-900">Genre</label>
+                  <div className="flex gap-2">
+                    {product.genders.map(g => (
+                      <button
+                        key={g}
+                        onClick={() => setSelectedGender(g)}
+                        className={`px-3 py-1 rounded-md border text-sm ${selectedGender === g ? 'bg-black text-white' : 'bg-white text-gray-700'}`}
+                      >
+                        {g}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {product.colors && (
+                <div className="mb-6 space-y-2">
+                  <label className="block text-sm font-medium text-gray-900">Couleur</label>
+                  <div className="flex gap-2">
+                    {product.colors.map((c, idx) => (
+                      <button
+                        key={c.name}
+                        onClick={() => setSelectedColor(c)}
+                        className={`w-8 h-8 rounded-full border-2 ${selectedColor?.name === c.name ? 'border-black' : 'border-gray-300'}`}
+                        style={{ backgroundColor: c.hex }}
+                      />
+                    ))}
+                  </div>
+                </div>
+              )}
 
               {/* Size Selection */}
               <div className="space-y-4 mb-8">

--- a/miral-cycling-project/project/components/ui/product-card.tsx
+++ b/miral-cycling-project/project/components/ui/product-card.tsx
@@ -108,6 +108,8 @@ export function ProductCard({ product, index }: ProductCardProps) {
                   name: product.name,
                   price: product.price,
                   size: product.sizes[0],
+                  gender: product.genders ? product.genders[0] : product.gender,
+                  color: product.colors ? product.colors[0].name : undefined,
                   image: product.images[0],
                 },
               });

--- a/miral-cycling-project/project/lib/cart-context.tsx
+++ b/miral-cycling-project/project/lib/cart-context.tsx
@@ -7,6 +7,8 @@ interface CartItem {
   name: string;
   price: number;
   size: string;
+  gender?: string;
+  color?: string;
   quantity: number;
   image: string;
 }
@@ -33,13 +35,20 @@ function cartReducer(state: CartState, action: CartAction): CartState {
   switch (action.type) {
     case 'ADD_ITEM': {
       const existingItem = state.items.find(
-        item => item.id === action.payload.id && item.size === action.payload.size
+        item =>
+          item.id === action.payload.id &&
+          item.size === action.payload.size &&
+          item.gender === action.payload.gender &&
+          item.color === action.payload.color
       );
 
       let newItems;
       if (existingItem) {
         newItems = state.items.map(item =>
-          item.id === action.payload.id && item.size === action.payload.size
+          item.id === action.payload.id &&
+            item.size === action.payload.size &&
+            item.gender === action.payload.gender &&
+            item.color === action.payload.color
             ? { ...item, quantity: item.quantity + 1 }
             : item
         );

--- a/miral-cycling-project/project/lib/constants.ts
+++ b/miral-cycling-project/project/lib/constants.ts
@@ -4,6 +4,24 @@ export const PRODUCT_COLLECTIONS = {
   terra: 'MIRAL Terra'
 } as const;
 
+export const COLLECTION_COLORS: Record<string, ColorOption[]> = {
+  aero: [
+    { name: 'Deep Black', hex: '#1A1A1A', image: '' },
+    { name: 'Carmine Red', hex: '#8B0000', image: '' },
+    { name: 'Graphite', hex: '#2F2F2F', image: '' }
+  ],
+  flow: [
+    { name: 'Mineral Blue', hex: '#3A5A80', image: '' },
+    { name: 'Sage Green', hex: '#8DAA91', image: '' },
+    { name: 'Ash White', hex: '#F2F2F2', image: '' }
+  ],
+  terra: [
+    { name: 'Earth Clay', hex: '#B25C3C', image: '' },
+    { name: 'Olive Green', hex: '#708238', image: '' },
+    { name: 'Sand Beige', hex: '#D8CAB8', image: '' }
+  ]
+};
+
 export const PRODUCT_CATEGORIES = {
   jerseys: 'Maillots',
   shorts: 'Cuissards',
@@ -26,6 +44,12 @@ export const PRODUCT_TYPES = {
   'accessoire': 'Accessoire'
 } as const;
 
+export interface ColorOption {
+  name: string;
+  hex: string;
+  image: string;
+}
+
 export interface Product {
   id: string;
   name: string;
@@ -36,6 +60,8 @@ export interface Product {
   price: number;
   originalPrice?: number;
   images: string[];
+  colors?: ColorOption[];
+  genders?: string[];
   description: string;
   features: string[];
   sizes: string[];
@@ -58,6 +84,8 @@ export const SAMPLE_PRODUCTS: Product[] = [
       'https://images.pexels.com/photos/6386956/pexels-photo-6386956.jpeg?auto=compress&cs=tinysrgb&w=800',
       'https://images.pexels.com/photos/6386942/pexels-photo-6386942.jpeg?auto=compress&cs=tinysrgb&w=800'
     ],
+    colors: COLLECTION_COLORS.aero,
+    genders: ['Male', 'Female'],
     description: 'Coupe aérodynamique, tissu compressif, mesh sous les bras, zip invisible. Conçu pour la performance pure.',
     features: [
       'Tissu compressif haute performance',
@@ -82,6 +110,8 @@ export const SAMPLE_PRODUCTS: Product[] = [
     images: [
       'https://images.pexels.com/photos/6386958/pexels-photo-6386958.jpeg?auto=compress&cs=tinysrgb&w=800'
     ],
+    colors: COLLECTION_COLORS.aero,
+    genders: ['Male', 'Female'],
     description: 'Parfait pour l\'été ou home trainer, léger, respirant. Performance maximale par temps chaud.',
     features: [
       'Ultra-léger et respirant',
@@ -105,6 +135,8 @@ export const SAMPLE_PRODUCTS: Product[] = [
     images: [
       'https://images.pexels.com/photos/6386937/pexels-photo-6386937.jpeg?auto=compress&cs=tinysrgb&w=800'
     ],
+    colors: COLLECTION_COLORS.aero,
+    genders: ['Male', 'Female'],
     description: 'Peau haute densité, coutures plates, bretelles en mesh. Le summum du confort pour la compétition.',
     features: [
       'Peau de chamois haute densité',
@@ -130,6 +162,8 @@ export const SAMPLE_PRODUCTS: Product[] = [
     images: [
       'https://images.pexels.com/photos/6386944/pexels-photo-6386944.jpeg?auto=compress&cs=tinysrgb&w=800'
     ],
+    colors: COLLECTION_COLORS.flow,
+    genders: ['Male', 'Female'],
     description: 'Confort respirant, tissu doux, poche triple, bande silicone. Idéal pour les longues sorties.',
     features: [
       'Tissu doux et respirant',
@@ -152,6 +186,8 @@ export const SAMPLE_PRODUCTS: Product[] = [
     images: [
       'https://images.pexels.com/photos/6386948/pexels-photo-6386948.jpeg?auto=compress&cs=tinysrgb&w=800'
     ],
+    colors: COLLECTION_COLORS.flow,
+    genders: ['Male', 'Female'],
     description: 'Confort respirant, tissu doux, poche triple, bande silicone. Coupe féminine ajustée.',
     features: [
       'Coupe féminine spécifique',
@@ -174,6 +210,8 @@ export const SAMPLE_PRODUCTS: Product[] = [
     images: [
       'https://images.pexels.com/photos/6386951/pexels-photo-6386951.jpeg?auto=compress&cs=tinysrgb&w=800'
     ],
+    colors: COLLECTION_COLORS.flow,
+    genders: ['Male', 'Female'],
     description: 'Grand confort longue distance, tissu souple, bande large. Parfait pour l\'endurance.',
     features: [
       'Peau de chamois longue distance',
@@ -196,6 +234,8 @@ export const SAMPLE_PRODUCTS: Product[] = [
     images: [
       'https://images.pexels.com/photos/6386953/pexels-photo-6386953.jpeg?auto=compress&cs=tinysrgb&w=800'
     ],
+    colors: COLLECTION_COLORS.flow,
+    genders: ['Male', 'Female'],
     description: 'Grand confort longue distance, tissu souple, bande large. Coupe féminine spécifique.',
     features: [
       'Peau de chamois féminine',
@@ -220,6 +260,8 @@ export const SAMPLE_PRODUCTS: Product[] = [
     images: [
       'https://images.pexels.com/photos/6386955/pexels-photo-6386955.jpeg?auto=compress&cs=tinysrgb&w=800'
     ],
+    colors: COLLECTION_COLORS.terra,
+    genders: ['Male', 'Female'],
     description: 'Résistant au vent, manches longues, zip étanche, col renforcé. Conçu pour l\'exploration.',
     features: [
       'Tissu coupe-vent',
@@ -243,6 +285,8 @@ export const SAMPLE_PRODUCTS: Product[] = [
     images: [
       'https://images.pexels.com/photos/6386959/pexels-photo-6386959.jpeg?auto=compress&cs=tinysrgb&w=800'
     ],
+    colors: COLLECTION_COLORS.terra,
+    genders: ['Male', 'Female'],
     description: 'Tissu renforcé, poches latérales, grip cuisse solide. Résistance maximale pour le gravel.',
     features: [
       'Tissu renforcé anti-abrasion',


### PR DESCRIPTION
## Summary
- extend `Product` type with color and gender options
- add collection color palette data
- wire variant selectors into product page
- include selected gender/color in cart actions
- keep layout stable during size selection via CSS scroll-lock rule

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685011a915a483279fe3060a28d0b43f