### PR TITLE
Improve collection gallery and header

### DIFF
--- a/miral-cycling-project/project/app/collections/page.tsx
+++ b/miral-cycling-project/project/app/collections/page.tsx
@@ -237,6 +237,14 @@ export default function CollectionsPage() {
                 {filteredProducts.map((product, index) => (
                   <ProductCard key={product.id} product={product} index={index} />
                 ))}
+                {Array.from({ length: Math.max(0, 8 - filteredProducts.length) }).map((_, i) => (
+                  <div
+                    key={`placeholder-${i}`}
+                    className="h-64 border-2 border-dashed rounded-lg flex items-center justify-center text-gray-400"
+                  >
+                    Bientôt disponible
+                  </div>
+                ))}
               </div>
             </>
           ) : (

--- a/miral-cycling-project/project/app/products/[id]/ProductPageClient.tsx
+++ b/miral-cycling-project/project/app/products/[id]/ProductPageClient.tsx
@@ -14,6 +14,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Breadcrumbs } from '@/components/layout/breadcrumbs';
 import { useLanguage } from '@/lib/language-context';
+import { ProductGallery } from '@/components/ui/product-gallery';
 
 interface ProductPageProps {
   params: {
@@ -24,7 +25,6 @@ interface ProductPageProps {
 export default function ProductPage({ params }: ProductPageProps) {
   const product = SAMPLE_PRODUCTS.find(p => p.id === params.id);
   const [selectedSize, setSelectedSize] = useState('');
-  const [selectedImage, setSelectedImage] = useState(0);
   const [selectedGender, setSelectedGender] = useState(product?.genders?.[0] || 'Male');
   const [selectedColor, setSelectedColor] = useState(product?.colors?.[0] || null);
   const { dispatch } = useCart();
@@ -86,43 +86,7 @@ export default function ProductPage({ params }: ProductPageProps) {
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-16">
           {/* Product Images */}
           <div className="space-y-4">
-            <motion.div
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              transition={{ duration: 0.5 }}
-              className="aspect-square bg-gray-100 rounded-lg overflow-hidden"
-            >
-              <Image
-                src={product.images[selectedImage]}
-                alt={product.name}
-                width={600}
-                height={600}
-                className="w-full h-full object-cover"
-              />
-            </motion.div>
-            
-            {/* Thumbnail Images */}
-            {product.images.length > 1 && (
-              <div className="flex gap-2">
-                {product.images.map((image, index) => (
-                  <button
-                    key={index}
-                    onClick={() => setSelectedImage(index)}
-                    className={`w-20 h-20 rounded-lg overflow-hidden border-2 transition-colors ${
-                      selectedImage === index ? 'border-black' : 'border-transparent'
-                    }`}
-                  >
-                    <Image
-                      src={image}
-                      alt={`${product.name} ${index + 1}`}
-                      width={80}
-                      height={80}
-                      className="w-full h-full object-cover"
-                    />
-                  </button>
-                ))}
-              </div>
-            )}
+            <ProductGallery images={product.images} />
           </div>
 
           {/* Product Info */}

--- a/miral-cycling-project/project/components/layout/header.tsx
+++ b/miral-cycling-project/project/components/layout/header.tsx
@@ -21,7 +21,7 @@ export function Header() {
   ];
 
   return (
-    <header className="fixed top-0 w-full z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
+    <header className="fixed top-0 left-0 right-0 w-full z-50 bg-black/90 text-white backdrop-blur-sm border-b border-gray-800 pr-[var(--removed-body-scroll-bar-size)]">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-16">
           {/* Logo */}
@@ -35,7 +35,7 @@ export function Header() {
               <Link
                 key={item.name}
                 href={item.href}
-                className="text-gray-700 hover:text-black transition-colors duration-200"
+                className="text-gray-200 hover:text-white transition-colors duration-200"
               >
                 {item.name}
               </Link>
@@ -43,7 +43,7 @@ export function Header() {
             <select
               value={lang}
               onChange={(e) => setLang(e.target.value as 'fr' | 'en')}
-              className="text-sm border border-gray-300 rounded-md bg-white px-2 py-1"
+              className="text-sm border border-gray-700 bg-black text-white rounded-md px-2 py-1"
             >
               <option value="fr">FR</option>
               <option value="en">EN</option>
@@ -89,14 +89,14 @@ export function Header() {
             initial={{ opacity: 0, height: 0 }}
             animate={{ opacity: 1, height: 'auto' }}
             exit={{ opacity: 0, height: 0 }}
-            className="md:hidden bg-white border-b border-gray-100"
+            className="md:hidden bg-black border-b border-gray-800 text-white"
           >
             <div className="px-4 py-4 space-y-4">
               {navigation.map((item) => (
                 <Link
                   key={item.name}
                   href={item.href}
-                  className="block text-gray-700 hover:text-black transition-colors duration-200"
+                  className="block text-gray-200 hover:text-white transition-colors duration-200"
                   onClick={() => setIsMenuOpen(false)}
                 >
                   {item.name}
@@ -104,14 +104,14 @@ export function Header() {
               ))}
               <Link
                 href="/account"
-                className="block text-gray-700 hover:text-black transition-colors duration-200"
+                className="block text-gray-200 hover:text-white transition-colors duration-200"
                 onClick={() => setIsMenuOpen(false)}
               >
                 {t.account}
               </Link>
               <Link
                 href="/cart"
-                className="block text-gray-700 hover:text-black transition-colors duration-200"
+                className="block text-gray-200 hover:text-white transition-colors duration-200"
                 onClick={() => setIsMenuOpen(false)}
               >
                 {t.cart}
@@ -119,7 +119,7 @@ export function Header() {
               <select
                 value={lang}
                 onChange={(e) => setLang(e.target.value as 'fr' | 'en')}
-                className="mt-2 w-full border border-gray-300 rounded-md px-2 py-1"
+                className="mt-2 w-full border border-gray-700 bg-black text-white rounded-md px-2 py-1"
               >
                 <option value="fr">FR</option>
                 <option value="en">EN</option>

--- a/miral-cycling-project/project/components/ui/product-card.tsx
+++ b/miral-cycling-project/project/components/ui/product-card.tsx
@@ -45,7 +45,7 @@ export function ProductCard({ product, index }: ProductCardProps) {
       initial={{ opacity: 0, y: 20 }}
       whileInView={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.5, delay: index * 0.1 }}
-      viewport={{ once: true }}
+      viewport={{ once: true, amount: 0.2 }}
       className="group relative bg-white rounded-lg overflow-hidden shadow-sm hover:shadow-lg transition-all duration-300"
     >
       {/* Product Image */}

--- a/miral-cycling-project/project/components/ui/product-gallery.tsx
+++ b/miral-cycling-project/project/components/ui/product-gallery.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Image from 'next/image';
+import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious } from './carousel';
+import type { CarouselApi } from './carousel';
+
+interface ProductGalleryProps {
+  images: string[];
+}
+
+export function ProductGallery({ images }: ProductGalleryProps) {
+  const [api, setApi] = useState<CarouselApi>();
+  const [selected, setSelected] = useState(0);
+
+  const slides = [...images];
+  while (slides.length < 4) {
+    slides.push(images[0]);
+  }
+
+  useEffect(() => {
+    if (!api) return;
+    setSelected(api.selectedScrollSnap());
+    api.on('select', () => setSelected(api.selectedScrollSnap()));
+  }, [api]);
+
+  return (
+    <div>
+      <Carousel setApi={setApi} opts={{ loop: true }} className="w-full">
+        <CarouselContent>
+          {slides.map((src, idx) => (
+            <CarouselItem key={idx} className="relative aspect-square">
+              <Image src={src} alt={`Product image ${idx + 1}`} fill className="object-cover rounded-lg" />
+            </CarouselItem>
+          ))}
+        </CarouselContent>
+        <CarouselPrevious />
+        <CarouselNext />
+      </Carousel>
+      {slides.length > 1 && (
+        <div className="flex gap-2 mt-4 justify-center">
+          {slides.map((src, idx) => (
+            <button
+              key={idx}
+              onClick={() => api?.scrollTo(idx)}
+              className={`relative w-16 h-16 overflow-hidden rounded-md border-2 transition-colors ${
+                selected === idx ? 'border-black' : 'border-transparent'
+              }`}
+            >
+              <Image src={src} alt="thumbnail" fill className="object-cover" />
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- style header consistently with dark theme
- use Carousel-based `ProductGallery`
- integrate gallery into product page
- show placeholders in collection grid
- adjust product card viewport for quicker reveal

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68501824a0f88327aea4b365ad6b3d18