### PR TITLE
Adjust header color and featured products

### DIFF
--- a/miral-cycling-project/project/components/layout/header.tsx
+++ b/miral-cycling-project/project/components/layout/header.tsx
@@ -21,7 +21,7 @@ export function Header() {
   ];
 
   return (
-    <header className="fixed top-0 left-0 right-0 w-full z-50 bg-black/90 text-white backdrop-blur-sm border-b border-gray-800 pr-[var(--removed-body-scroll-bar-size)]">
+    <header className="fixed top-0 left-0 right-0 w-full z-50 bg-white text-black backdrop-blur-sm border-b border-gray-200 pr-[var(--removed-body-scroll-bar-size)]">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-16">
           {/* Logo */}
@@ -35,7 +35,7 @@ export function Header() {
               <Link
                 key={item.name}
                 href={item.href}
-                className="text-gray-200 hover:text-white transition-colors duration-200"
+                className="text-gray-800 hover:text-black transition-colors duration-200"
               >
                 {item.name}
               </Link>
@@ -43,7 +43,7 @@ export function Header() {
             <select
               value={lang}
               onChange={(e) => setLang(e.target.value as 'fr' | 'en')}
-              className="text-sm border border-gray-700 bg-black text-white rounded-md px-2 py-1"
+              className="text-sm border border-gray-300 bg-white text-black rounded-md px-2 py-1"
             >
               <option value="fr">FR</option>
               <option value="en">EN</option>
@@ -89,14 +89,14 @@ export function Header() {
             initial={{ opacity: 0, height: 0 }}
             animate={{ opacity: 1, height: 'auto' }}
             exit={{ opacity: 0, height: 0 }}
-            className="md:hidden bg-black border-b border-gray-800 text-white"
+            className="md:hidden bg-white border-b border-gray-200 text-black"
           >
             <div className="px-4 py-4 space-y-4">
               {navigation.map((item) => (
                 <Link
                   key={item.name}
                   href={item.href}
-                  className="block text-gray-200 hover:text-white transition-colors duration-200"
+                  className="block text-gray-800 hover:text-black transition-colors duration-200"
                   onClick={() => setIsMenuOpen(false)}
                 >
                   {item.name}
@@ -104,14 +104,14 @@ export function Header() {
               ))}
               <Link
                 href="/account"
-                className="block text-gray-200 hover:text-white transition-colors duration-200"
+                className="block text-gray-800 hover:text-black transition-colors duration-200"
                 onClick={() => setIsMenuOpen(false)}
               >
                 {t.account}
               </Link>
               <Link
                 href="/cart"
-                className="block text-gray-200 hover:text-white transition-colors duration-200"
+                className="block text-gray-800 hover:text-black transition-colors duration-200"
                 onClick={() => setIsMenuOpen(false)}
               >
                 {t.cart}
@@ -119,7 +119,7 @@ export function Header() {
               <select
                 value={lang}
                 onChange={(e) => setLang(e.target.value as 'fr' | 'en')}
-                className="mt-2 w-full border border-gray-700 bg-black text-white rounded-md px-2 py-1"
+                className="mt-2 w-full border border-gray-300 bg-white text-black rounded-md px-2 py-1"
               >
                 <option value="fr">FR</option>
                 <option value="en">EN</option>

--- a/miral-cycling-project/project/components/ui/featured-products.tsx
+++ b/miral-cycling-project/project/components/ui/featured-products.tsx
@@ -8,7 +8,7 @@ import { ProductCard } from '@/components/ui/product-card';
 import { Button } from '@/components/ui/button';
 
 export function FeaturedProducts() {
-  const featuredProducts = SAMPLE_PRODUCTS.filter(product => product.isFeatured).slice(0, 4);
+  const featuredProducts = SAMPLE_PRODUCTS.filter(product => product.isFeatured).slice(0, 8);
 
   return (
     <section className="py-20 bg-gray-50">

--- a/miral-cycling-project/project/lib/constants.ts
+++ b/miral-cycling-project/project/lib/constants.ts
@@ -173,7 +173,8 @@ export const SAMPLE_PRODUCTS: Product[] = [
       'Protection UV 30+'
     ],
     sizes: ['S', 'M', 'L', 'XL', 'XXL'],
-    inStock: true
+    inStock: true,
+    isFeatured: true
   },
   {
     id: 'flow-lite-jersey-women',
@@ -197,7 +198,8 @@ export const SAMPLE_PRODUCTS: Product[] = [
       'Coutures plates'
     ],
     sizes: ['XS', 'S', 'M', 'L', 'XL'],
-    inStock: true
+    inStock: true,
+    isFeatured: true
   },
   {
     id: 'flow-fit-bib-men',
@@ -221,7 +223,8 @@ export const SAMPLE_PRODUCTS: Product[] = [
       'Compression douce'
     ],
     sizes: ['S', 'M', 'L', 'XL', 'XXL'],
-    inStock: true
+    inStock: true,
+    isFeatured: true
   },
   {
     id: 'flow-fit-bib-women',
@@ -245,7 +248,8 @@ export const SAMPLE_PRODUCTS: Product[] = [
       'Compression douce'
     ],
     sizes: ['XS', 'S', 'M', 'L', 'XL'],
-    inStock: true
+    inStock: true,
+    isFeatured: true
   },
 
   // MIRAL Terra Collection
@@ -272,7 +276,8 @@ export const SAMPLE_PRODUCTS: Product[] = [
     ],
     sizes: ['XS', 'S', 'M', 'L', 'XL'],
     inStock: true,
-    isNew: true
+    isNew: true,
+    isFeatured: true
   },
   {
     id: 'terra-grip-bib',


### PR DESCRIPTION
## Summary
- switch header background to white
- ensure all header controls match the light theme
- show eight featured products on the home page
- mark additional products as featured

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68501dca19808327b478792b541c52f4